### PR TITLE
Introducing GraphQL exampel of schema stitching with HotChocolate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 # Mono auto generated files
 mono_crash.*
 
+# Ignore development json configurations
+appsettings.Development.json
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/DotnetExploration.sln
+++ b/DotnetExploration.sln
@@ -9,6 +9,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Web", "Web", "{46FAE86F-B6F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Web.MinimalApi", "src\Web\Web.MinimalApi\Web.MinimalApi.csproj", "{94D44492-41E9-499C-8C83-12899B05F11A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Web.Chillicream", "Web.Chillicream", "{E0ABFBF7-23F7-4366-8FE6-2AB82F7E9874}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Web.Chillicream.SchemaStiching", "src\Web\Web.Chillicream\Web.Chillicream.SchemaStiching\Web.Chillicream.SchemaStiching.csproj", "{B38B20D2-7624-48E2-935E-4ED5EF55CCA9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -22,9 +26,15 @@ Global
 		{94D44492-41E9-499C-8C83-12899B05F11A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{94D44492-41E9-499C-8C83-12899B05F11A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{94D44492-41E9-499C-8C83-12899B05F11A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B38B20D2-7624-48E2-935E-4ED5EF55CCA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B38B20D2-7624-48E2-935E-4ED5EF55CCA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B38B20D2-7624-48E2-935E-4ED5EF55CCA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B38B20D2-7624-48E2-935E-4ED5EF55CCA9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{46FAE86F-B6F6-42E6-90F0-B4A34B452C4B} = {CA64A8A7-5E5B-485D-8F4F-21723D12E3BA}
 		{94D44492-41E9-499C-8C83-12899B05F11A} = {46FAE86F-B6F6-42E6-90F0-B4A34B452C4B}
+		{E0ABFBF7-23F7-4366-8FE6-2AB82F7E9874} = {46FAE86F-B6F6-42E6-90F0-B4A34B452C4B}
+		{B38B20D2-7624-48E2-935E-4ED5EF55CCA9} = {E0ABFBF7-23F7-4366-8FE6-2AB82F7E9874}
 	EndGlobalSection
 EndGlobal

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Common/WellKnownSchemaName.cs
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Common/WellKnownSchemaName.cs
@@ -1,0 +1,6 @@
+namespace DotnetExploration.Web.Chillicream.SchemaStitching.Common;
+
+public static class WellKnownSchemaName
+{
+    public const string Github = "github";
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/ExampleQueries/ratelimit.graphql
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/ExampleQueries/ratelimit.graphql
@@ -1,0 +1,9 @@
+query rateLimitQuery {
+  rateLimit {
+    limit
+    cost
+    remaining
+    resetAt
+    used
+  }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/ExampleQueries/userInformation.graphql
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/ExampleQueries/userInformation.graphql
@@ -1,0 +1,7 @@
+query userInformationQuery {
+  user(login: "asabla") {
+    id
+    name
+    avatarUrl
+  }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/Base64StringType.cs
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/Base64StringType.cs
@@ -1,0 +1,6 @@
+namespace DotnetExploration.Web.Chillicream.SchemaStitching.Github.Types;
+
+public class Base64StringType : StringType
+{
+    public Base64StringType() : base("Base64String") { }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/GitObjectIDType.cs
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/GitObjectIDType.cs
@@ -1,0 +1,6 @@
+namespace DotnetExploration.Web.Chillicream.SchemaStitching.Github.Types;
+
+public class GitObjectIDType : StringType
+{
+    public GitObjectIDType() : base("GitObjectID") { }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/GitSSHRemoteType.cs
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/GitSSHRemoteType.cs
@@ -1,0 +1,6 @@
+namespace DotnetExploration.Web.Chillicream.SchemaStitching.Github.Types;
+
+public class GitSSHRemoteType : StringType
+{
+    public GitSSHRemoteType() : base("GitSSHRemote") { }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/GitTimestampType.cs
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/GitTimestampType.cs
@@ -1,0 +1,6 @@
+namespace DotnetExploration.Web.Chillicream.SchemaStitching.Github.Types;
+
+public class GitTimestampType : IntType
+{
+    public GitTimestampType() : base("GitTimestamp") { }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/HTMLType.cs
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/HTMLType.cs
@@ -1,0 +1,6 @@
+namespace DotnetExploration.Web.Chillicream.SchemaStitching.Github.Types;
+
+public class HTMLType : StringType
+{
+    public HTMLType() : base("HTML") { }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/PreciseDateTimeType.cs
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/PreciseDateTimeType.cs
@@ -1,0 +1,6 @@
+namespace DotnetExploration.Web.Chillicream.SchemaStitching.Github.Types;
+
+public class PreciseDateTimeType : StringType
+{
+    public PreciseDateTimeType() : base("PreciseDateTime") { }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/URIType.cs
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/URIType.cs
@@ -1,0 +1,6 @@
+namespace DotnetExploration.Web.Chillicream.SchemaStitching.Github.Types;
+
+public class URIType : StringType
+{
+    public URIType() : base("URI") { }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/X509CertificateType.cs
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Github/Types/X509CertificateType.cs
@@ -1,0 +1,6 @@
+namespace DotnetExploration.Web.Chillicream.SchemaStitching.Github.Types;
+
+public class X509CertificateType : StringType
+{
+    public X509CertificateType() : base("X509Certificate") { }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Program.cs
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Program.cs
@@ -1,0 +1,50 @@
+using System.Net.Http.Headers;
+
+using DotnetExploration.Web.Chillicream.SchemaStitching.Common;
+using DotnetExploration.Web.Chillicream.SchemaStitching.Github.Types;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Register HttpClient used by HotChocolate to stitch Githubs schema
+builder.Services
+    .AddHttpClient(WellKnownSchemaName.Github, c =>
+    {
+        c.BaseAddress = new Uri("https://api.github.com/graphql");
+        c.DefaultRequestHeaders.Add("Authorization", $"bearer {builder.Configuration.GetConnectionString("GithubToken")}");
+        c.DefaultRequestHeaders.Add("Accept", "application/json");
+
+        // User-agent is required, otherwise you're going to be hit with a 403
+        c.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Web.Chillicream.Schemastiching.example", "0.1"));
+    });
+
+// Register Hotchocolate GraphQL server with types
+builder.Services
+    .AddGraphQLServer()
+    .AddRemoteSchema(WellKnownSchemaName.Github)
+        .AddType<GitObjectIDType>()
+        .AddType<URIType>()
+        .AddType<PreciseDateTimeType>()
+        .AddType<Base64StringType>()
+        .AddType<HTMLType>()
+        .AddType<X509CertificateType>()
+        .AddType<GitTimestampType>()
+        .AddType<GitSSHRemoteType>();
+
+// We have to specifically add types for named schema, otherwise
+// hotchocolate won't know were they belong to.
+builder.Services
+    .AddGraphQL(WellKnownSchemaName.Github)
+        .AddType<GitObjectIDType>()
+        .AddType<URIType>()
+        .AddType<PreciseDateTimeType>()
+        .AddType<Base64StringType>()
+        .AddType<HTMLType>()
+        .AddType<X509CertificateType>()
+        .AddType<GitTimestampType>()
+        .AddType<GitSSHRemoteType>();
+
+var app = builder.Build();
+
+app.MapGraphQL();
+
+app.Run();

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Properties/launchSettings.json
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Properties/launchSettings.json
@@ -1,0 +1,37 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:28695",
+      "sslPort": 44340
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5129",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7280;http://localhost:5129",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Web.Chillicream.SchemaStiching.csproj
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/Web.Chillicream.SchemaStiching.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="HotChocolate.AspNetCore" Version="12.15.2" />
+    <PackageReference Include="HotChocolate.Stitching" Version="12.15.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/appsettings.json
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "GithubToken": ""
+  }
+}

--- a/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/readme.md
+++ b/src/Web/Web.Chillicream/Web.Chillicream.SchemaStiching/readme.md
@@ -1,0 +1,5 @@
+# Using Hotchocolate to stitch github GraphQL endpoint
+
+This project aims to show how you could schema sticht in Githubs own GraphQL endpoint using a personal access token.
+
+The application is available at: [http://localhost:5129/graphql](http://localhost:5129/graphql)


### PR DESCRIPTION
First steps on how to stitch multiple schemas (in this case remote) into
one. In this setup we're using Githubs public GraphQL endpoint in order
to expose it locally.

You need to setup a Github classic token in order to test this solution.
Also included two example queries.

You can read more about HotChocolate and Chillicream at their [website](https://chillicream.com/).